### PR TITLE
fix: striped background on tables

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -71,7 +71,11 @@ export const Layout = ({ children }: { children: ReactNode }): ReactElement => {
       </Drawer>
       {/* mobilenav */}
       <MobileNav onOpen={onOpen} />
-      <Box ml={{ base: 0, md: 60 }} p="4">
+      <Box
+        ml={{ base: 0, md: 60 }}
+        p="4"
+        bg={useColorModeValue("gray.100", "gray.900")}
+      >
         {children}
       </Box>
     </Box>

--- a/src/components/tables/DatabasesTable.tsx
+++ b/src/components/tables/DatabasesTable.tsx
@@ -74,7 +74,7 @@ export const DatabasesTable = (
   };
 
   return (
-    <Box overflowX="auto" width="full">
+    <Box overflowX="auto" width="full" bg="white">
       <Table variant="striped">
         <TableCaption>
           Showing {data.length} out of {props.total} documents

--- a/src/components/tables/ExecutionsTable.tsx
+++ b/src/components/tables/ExecutionsTable.tsx
@@ -74,7 +74,7 @@ export const ExecutionsTable = (props: Models.ExecutionList): ReactElement => {
   );
 
   return (
-    <Box overflowX="auto" width="full">
+    <Box overflowX="auto" width="full" bg="white">
       <Table variant="striped">
         <TableCaption>
           Showing {data.length} out of {props.total} executions

--- a/src/components/tables/RealtimeTable.tsx
+++ b/src/components/tables/RealtimeTable.tsx
@@ -71,7 +71,7 @@ export const RealtimeTable = (props: {
   const [modalBody, setModalBody] = useState("");
 
   return (
-    <Box overflowX="auto" width="full">
+    <Box overflowX="auto" width="full" bg="white">
       <Table variant="striped">
         <TableCaption>Showing {data.length} events</TableCaption>
 

--- a/src/components/tables/StorageTable.tsx
+++ b/src/components/tables/StorageTable.tsx
@@ -71,7 +71,7 @@ export const StorageTable = (props: Models.FileList): ReactElement => {
   );
 
   return (
-    <Box overflowX="auto" width="full">
+    <Box overflowX="auto" width="full" bg="white">
       <Table variant="striped">
         <TableCaption>
           Showing {data.length} out of {props.total} files

--- a/src/components/tables/TeamMembershipsTable.tsx
+++ b/src/components/tables/TeamMembershipsTable.tsx
@@ -70,7 +70,7 @@ export const TeamMembershipsTable = (
   );
 
   return (
-    <Box overflowX="auto" width="full">
+    <Box overflowX="auto" width="full" bg="white">
       <Table variant="striped">
         <TableCaption>
           Showing {data.length} out of {props.total} teams

--- a/src/components/tables/TeamsTable.tsx
+++ b/src/components/tables/TeamsTable.tsx
@@ -56,7 +56,7 @@ export const TeamsTable = (
   );
 
   return (
-    <Box overflowX="auto" width="full">
+    <Box overflowX="auto" width="full" bg="white">
       <Table variant="striped">
         <TableCaption>
           Showing {data.length} out of {props.total} teams


### PR DESCRIPTION
The striped background on tables was not visible because the background color of the container matched the striping.

By setting the background of the container to white, the striping became visible.

In addition, the grey background needed to be added to a parent container further up to ensure the grey background extended as the table grew.